### PR TITLE
make this libarry give no warnings on go fmt

### DIFF
--- a/bezeir.go
+++ b/bezeir.go
@@ -2,8 +2,6 @@ package svg
 
 import "math"
 
-// cubicBezier
-//
 type cubicBezier struct {
 	controlpoints [4][2]float64
 	vertices      [][2]float64
@@ -96,11 +94,10 @@ func (c *cubicBezier) recursiveInterpolate(limit int, level int) [][2]float64 {
 		c2.controlpoints[3] = c.controlpoints[3]
 		vertices = append(vertices, c2.recursiveInterpolate(limit-1, c.level+1)...)
 		return vertices
-	} else {
-		var vertices [][2]float64
-		vertices = append(vertices, c.controlpoints[0])
-		vertices = append(vertices, m1234)
-		vertices = append(vertices, c.controlpoints[3])
-		return vertices
 	}
+	var vertices [][2]float64
+	vertices = append(vertices, c.controlpoints[0])
+	vertices = append(vertices, m1234)
+	vertices = append(vertices, c.controlpoints[3])
+	return vertices
 }

--- a/circle.go
+++ b/circle.go
@@ -2,8 +2,9 @@ package svg
 
 import mt "github.com/rustyoz/Mtransform"
 
+//Circle contains the data from a circle svg element
 type Circle struct {
-	Id        string `xml:"id,attr"`
+	ID        string `xml:"id,attr"`
 	Transform string `xml:"transform,attr"`
 	Style     string `xml:"style,attr"`
 	Cx        string `xml:"cx,attr"`

--- a/ellipse.go
+++ b/ellipse.go
@@ -2,8 +2,9 @@ package svg
 
 import mt "github.com/rustyoz/Mtransform"
 
+//Ellipse contains the data from a ellipse svg element
 type Ellipse struct {
-	Id        string `xml:"id,attr"`
+	ID        string `xml:"id,attr"`
 	Transform string `xml:"transform,attr"`
 	Style     string `xml:"style,attr"`
 	Cx        string `xml:"cx,attr"`

--- a/line.go
+++ b/line.go
@@ -2,8 +2,9 @@ package svg
 
 import mt "github.com/rustyoz/Mtransform"
 
+//Line contains the data from a line svg element
 type Line struct {
-	Id        string `xml:"id,attr"`
+	ID        string `xml:"id,attr"`
 	Transform string `xml:"transform,attr"`
 	Style     string `xml:"style,attr"`
 	X1        string `xml:"x1,attr"`

--- a/parser.go
+++ b/parser.go
@@ -60,7 +60,7 @@ func parseTransform(tstring string) (mt.Transform, error) {
 		switch i.Type {
 		case gl.ItemEOS:
 			return mt.Identity(),
-				fmt.Errorf("transform parse failed.")
+				fmt.Errorf("transform parse failed")
 		case gl.ItemWord:
 			switch i.Value {
 			case "matrix":

--- a/path.go
+++ b/path.go
@@ -8,8 +8,9 @@ import (
 	gl "github.com/rustyoz/genericlexer"
 )
 
+//Path contains the data from a path svg element
 type Path struct {
-	Id              string `xml:"id,attr"`
+	ID              string `xml:"id,attr"`
 	D               string `xml:"d,attr"`
 	Style           string `xml:"style,attr"`
 	TransformString string `xml:"transform,attr"`
@@ -19,8 +20,7 @@ type Path struct {
 	group           *Group
 }
 
-// Segment
-// A segment of a path that contains a list of connected points, its stroke Width and if the segment forms a closed loop.
+// Segment is a segment of a path that contains a list of connected points, its stroke Width and if the segment forms a closed loop.
 // Points are defined in world space after any matrix transformation is applied.
 type Segment struct {
 	Width  float64
@@ -48,7 +48,7 @@ type pathDescriptionParser struct {
 	peekcount      int
 	lasttuple      Tuple
 	transform      mt.Transform
-	svg            *Svg
+	svg            *SVG
 	currentsegment *Segment
 }
 
@@ -58,8 +58,7 @@ func newPathDParse() *pathDescriptionParser {
 	return pdp
 }
 
-// Parse()
-// interprets path description, transform and style atttributes to create a channel of segments.
+// Parse interprets path description, transform and style atttributes to create a channel of segments.
 func (p *Path) Parse() chan Segment {
 	p.parseStyle()
 	pdp := newPathDParse()
@@ -75,7 +74,7 @@ func (p *Path) Parse() chan Segment {
 	pdp.transform = mt.MultiplyTransforms(pdp.transform, *p.group.Transform)
 	pdp.transform = mt.MultiplyTransforms(pdp.transform, pathTransform)
 	p.Segments = make(chan Segment)
-	l, _ := gl.Lex(fmt.Sprint(p.Id), p.D)
+	l, _ := gl.Lex(fmt.Sprint(p.ID), p.D)
 	pdp.lex = *l
 	go func() {
 		defer close(p.Segments)

--- a/polygon.go
+++ b/polygon.go
@@ -2,10 +2,9 @@ package svg
 
 import mt "github.com/rustyoz/Mtransform"
 
-// Polygon
-// Closed shape of straight line segments
+//Polygon contains the data from a polygon svg element
 type Polygon struct {
-	Id        string `xml:"id,attr"`
+	ID        string `xml:"id,attr"`
 	Transform string `xml:"transform,attr"`
 	Style     string `xml:"style,attr"`
 	Points    string `xml:"points,attr"`

--- a/polyline.go
+++ b/polyline.go
@@ -2,10 +2,9 @@ package svg
 
 import mt "github.com/rustyoz/Mtransform"
 
-// PolyLine
-// set of connected line segments that typically form a closed shape.
+// PolyLine is a set of connected line segments that typically form a closed shape.
 type PolyLine struct {
-	Id        string `xml:"id,attr"`
+	ID        string `xml:"id,attr"`
 	Transform string `xml:"transform,attr"`
 	Style     string `xml:"style,attr"`
 	Points    string `xml:"points,attr"`

--- a/rect.go
+++ b/rect.go
@@ -2,8 +2,9 @@ package svg
 
 import mt "github.com/rustyoz/Mtransform"
 
+//Rect contains the data from a rect svg element
 type Rect struct {
-	Id        string `xml:"id,attr"`
+	ID        string `xml:"id,attr"`
 	Width     string `xml:"width,attr"`
 	Height    string `xml:"height,attr"`
 	Transform string `xml:"transform,attr"`

--- a/svg.go
+++ b/svg.go
@@ -3,6 +3,7 @@ package svg
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
 	"strconv"
 
 	mt "github.com/rustyoz/Mtransform"
@@ -108,7 +109,32 @@ func ParseSvg(str string, name string, scale float64) (*Svg, error) {
 	if err != nil {
 		return nil, fmt.Errorf("ParseSvg Error: %v\n", err)
 	}
-	fmt.Println(len(svg.Groups))
+	for i := range svg.Groups {
+		svg.Groups[i].SetOwner(&svg)
+		if svg.Groups[i].Transform == nil {
+			svg.Groups[i].Transform = mt.NewTransform()
+		}
+	}
+	return &svg, nil
+}
+
+func ParseReader(reader io.Reader, name string, scale float64) (*Svg, error) {
+	var svg Svg
+	svg.Name = name
+	svg.Transform = mt.NewTransform()
+	if scale > 0 {
+		svg.Transform.Scale(scale, scale)
+		svg.scale = scale
+	}
+	if scale < 0 {
+		svg.Transform.Scale(1.0/-scale, 1.0/-scale)
+		svg.scale = 1.0 / -scale
+	}
+	dec := xml.NewDecoder(reader)
+	err := dec.Decode(&svg)
+	if err != nil {
+		return nil, fmt.Errorf("failled to parse SVG: %v\n", err)
+	}
 	for i := range svg.Groups {
 		svg.Groups[i].SetOwner(&svg)
 		if svg.Groups[i].Transform == nil {

--- a/svg.go
+++ b/svg.go
@@ -9,9 +9,11 @@ import (
 	mt "github.com/rustyoz/Mtransform"
 )
 
+//Tuple is a container for 2 float64s
 type Tuple [2]float64
 
-type Svg struct {
+//SVG is a container the svg
+type SVG struct {
 	Title     string  `xml:"title"`
 	Groups    []Group `xml:"g"`
 	Name      string
@@ -19,8 +21,9 @@ type Svg struct {
 	scale     float64
 }
 
+//Group contains the data from a group svg element
 type Group struct {
-	Id              string
+	ID              string
 	Stroke          string
 	StrokeWidth     int32
 	Fill            string
@@ -29,23 +32,24 @@ type Group struct {
 	TransformString string
 	Transform       *mt.Transform // row, column
 	Parent          *Group
-	Owner           *Svg
+	Owner           *SVG
 }
 
-// Implements encoding.xml.Unmarshaler interface
+//UnmarshalXML implements encoding.xml.Unmarshaler interface
 func (g *Group) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) error {
 	for _, attr := range start.Attr {
 		switch attr.Name.Local {
 		case "id":
-			g.Id = attr.Value
+			g.ID = attr.Value
 		case "stroke":
 			g.Stroke = attr.Value
 		case "stroke-width":
-			if intValue, err := strconv.ParseInt(attr.Value, 10, 32); err != nil {
+			intValue, err := strconv.ParseInt(attr.Value, 10, 32)
+			if err != nil {
 				return err
-			} else {
-				g.StrokeWidth = int32(intValue)
 			}
+			g.StrokeWidth = int32(intValue)
+
 		case "fill":
 			g.Fill = attr.Value
 		case "fill-rule":
@@ -79,12 +83,11 @@ func (g *Group) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) error
 				elementStruct = &Path{group: g, strokeWidth: 1}
 
 			}
-
-			if err = decoder.DecodeElement(elementStruct, &tok); err != nil {
+			err = decoder.DecodeElement(elementStruct, &tok)
+			if err != nil {
 				return fmt.Errorf("Error decoding element of Group\n%s", err)
-			} else {
-				g.Elements = append(g.Elements, elementStruct)
 			}
+			g.Elements = append(g.Elements, elementStruct)
 
 		case xml.EndElement:
 			return nil
@@ -92,8 +95,9 @@ func (g *Group) UnmarshalXML(decoder *xml.Decoder, start xml.StartElement) error
 	}
 }
 
-func ParseSvg(str string, name string, scale float64) (*Svg, error) {
-	var svg Svg
+//ParseSVG parses a string into the SVG type
+func ParseSVG(str string, name string, scale float64) (*SVG, error) {
+	var svg SVG
 	svg.Name = name
 	svg.Transform = mt.NewTransform()
 	if scale > 0 {
@@ -107,7 +111,7 @@ func ParseSvg(str string, name string, scale float64) (*Svg, error) {
 
 	err := xml.Unmarshal([]byte(str), &svg)
 	if err != nil {
-		return nil, fmt.Errorf("ParseSvg Error: %v\n", err)
+		return nil, fmt.Errorf("parseSvg Error: %v", err)
 	}
 	for i := range svg.Groups {
 		svg.Groups[i].SetOwner(&svg)
@@ -118,8 +122,9 @@ func ParseSvg(str string, name string, scale float64) (*Svg, error) {
 	return &svg, nil
 }
 
-func ParseReader(reader io.Reader, name string, scale float64) (*Svg, error) {
-	var svg Svg
+//ParseReader parses an io.Reader into the SVG type
+func ParseReader(reader io.Reader, name string, scale float64) (*SVG, error) {
+	var svg SVG
 	svg.Name = name
 	svg.Transform = mt.NewTransform()
 	if scale > 0 {
@@ -133,7 +138,7 @@ func ParseReader(reader io.Reader, name string, scale float64) (*Svg, error) {
 	dec := xml.NewDecoder(reader)
 	err := dec.Decode(&svg)
 	if err != nil {
-		return nil, fmt.Errorf("failled to parse SVG: %v\n", err)
+		return nil, fmt.Errorf("failled to parse SVG: %v", err)
 	}
 	for i := range svg.Groups {
 		svg.Groups[i].SetOwner(&svg)
@@ -144,7 +149,8 @@ func ParseReader(reader io.Reader, name string, scale float64) (*Svg, error) {
 	return &svg, nil
 }
 
-func (g *Group) SetOwner(svg *Svg) {
+//SetOwner sets the owner of a group
+func (g *Group) SetOwner(svg *SVG) {
 	g.Owner = svg
 	for _, gn := range g.Elements {
 		switch gn.(type) {


### PR DESCRIPTION
removed all inconsistencies and go fmt warnings. 
recommended to add a git tag before (and after) to be able to use old(and new) version of the library as there are naming changes in the API